### PR TITLE
Update RoomLoader constructor

### DIFF
--- a/GMRoomLoader/scripts/RoomLoaderMain/RoomLoaderMain.gml
+++ b/GMRoomLoader/scripts/RoomLoaderMain/RoomLoaderMain.gml
@@ -463,4 +463,4 @@ function RoomLoader() constructor {
 	#endregion
 }
 
-RoomLoader();
+new RoomLoader();


### PR DESCRIPTION
With the latest game maker version RoomLoader crashes on start

Seems like Game Maker's just being more finicky about the syntax, so the fix wasn't too bad